### PR TITLE
fix for `--watch`

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -37,7 +37,9 @@ module.exports = async function () {
       DynamoDbLocal.configureInstaller(installerConfig);
     }
 
-    global.__DYNAMODB__ = await DynamoDbLocal.launch(port, null, options);
+    if (!global.__DYNAMODB__) {
+      global.__DYNAMODB__ = await DynamoDbLocal.launch(port, null, options);
+    }
   }
 
   await createTables(dynamoDB, newTables);

--- a/teardown.js
+++ b/teardown.js
@@ -1,11 +1,11 @@
 const DynamoDbLocal = require('dynamodb-local');
 const debug = require('debug')('jest-dynamodb');
 
-module.exports = async function () {
+module.exports = async function (teardownArgs) {
   // eslint-disable-next-line no-console
   debug('Teardown DynamoDB');
 
-  if (global.__DYNAMODB__) {
+  if (global.__DYNAMODB__ && !(teardownArgs.watch || teardownArgs.watchAll)) {
     await DynamoDbLocal.stopChild(global.__DYNAMODB__);
   } else {
     const dynamoDB = global.__DYNAMODB_CLIENT__;


### PR DESCRIPTION
When executing jest with --watch or --watchAll, jest-dynamo causes
problems attempting to relaunch the service if it's already running.
This intercepts jest's flags on watch or watchAll to avoid terminating
ddb local during a test run, and doesn't restart it during setup if it
already exists.